### PR TITLE
Minor style tweaks

### DIFF
--- a/src/styles/components/_mobile-nav.scss
+++ b/src/styles/components/_mobile-nav.scss
@@ -13,6 +13,7 @@
   }
 
   a {
+    color: $smoke;
     text-decoration: none;
   }
 

--- a/src/styles/components/_subscribe-form.scss
+++ b/src/styles/components/_subscribe-form.scss
@@ -2,10 +2,22 @@
   background: $platinum;
   padding: $vertical-spacing 0;
 
+  form {
+    display: flex;
+    align-items: center;
+  }
+
+  &-email,
+  &-submit {
+    min-height: 37px;
+    border-radius: 0;
+    border: 1px solid $blue;
+  }
+
   &-email {
     padding: 0.5rem;
     margin: 0;
-    border: 1px solid $blue;
+    background-color: $white;
   }
 
   &-submit {
@@ -14,6 +26,7 @@
     background-color: $blue;
     color: $platinum;
     transition: background-color 0.25s ease-out;
+    cursor: pointer;
 
     @media (any-hover: hover) {
       &:hover {
@@ -21,6 +34,7 @@
       }
     }
   }
+
   &-success,
   &-error {
     padding-top: 1rem;


### PR DESCRIPTION
1. Make Mobile Navigation links `$smoke` color
2. Style signup form to have no border-radius and vertically align center by making `form` `display:flex`