### PR TITLE
Instagram page updates, add margin to blogCta

### DIFF
--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -24,7 +24,7 @@ const GalleryThumbnail = ({ item, idx }) => {
 
 const Gallery = ({ imageList }) => (
   <div className="Gallery">
-    {imageList.map((item, idx) => (
+    {imageList.reverse().map((item, idx) => (
       <GalleryThumbnail key={idx} item={item} idx={idx} />
     ))}
   </div>
@@ -34,7 +34,7 @@ Gallery.propTypes = {
   imageList: PropTypes.arrayOf(
     PropTypes.shape({
       image: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-      altText: PropTypes.string
+      title: PropTypes.string
     })
   )
 };

--- a/src/pages/instagram/index.md
+++ b/src/pages/instagram/index.md
@@ -2,13 +2,11 @@
 templateKey: instagram-page
 title: Instagram | @yousaiditchewie
 gallery:
-  - altText: >-
-      Click to go to my article - How Musicians Can Grow Their Audience With
+  - title: How Musicians Can Grow Their Audience With
       Content Marketing
     image: /img/content-marketing-link-image.jpg
     linkUrl: /blog/how-musicians-can-grow-their-audience-with-content-marketing
-  - altText: Hybrid drumming for the modern age
+  - title: Hybrid drumming for the modern age
     image: /img/hybrid-drumming-in-the-modern-age.jpg
     linkUrl: /blog/hybrid-drumming-in-the-modern-age
 ---
-

--- a/src/styles/components/_blog-cta.scss
+++ b/src/styles/components/_blog-cta.scss
@@ -1,8 +1,7 @@
 .BlogCta {
   padding: 2rem $container-padding;
-  //   border: 1px solid $blue;
-  //   border-bottom: 1px solid $blue;
   margin-top: 2rem;
+  margin-bottom: 2rem;
   background-color: $platinum;
   text-align: center;
 

--- a/src/styles/components/_gallery.scss
+++ b/src/styles/components/_gallery.scss
@@ -10,11 +10,7 @@
 
   &-image {
     margin: 0.5rem 0.5rem 1.5rem 0.5rem;
-    width: calc(100% - 1rem);
-
-    @media (min-width: $tablet) {
-      width: calc(50% - 1rem);
-    }
+    width: calc(50% - 1rem);
 
     @media (min-width: $portable) {
       width: calc(33.333% - 1rem);

--- a/src/templates/instagram-page.js
+++ b/src/templates/instagram-page.js
@@ -20,6 +20,15 @@ const InstagramPage = ({ data }) => {
   const { markdownRemark: post } = data;
   return (
     <Layout>
+      <h1
+        className="container"
+        style={{
+          fontSize: '1rem',
+          textAlign: 'center'
+        }}
+      >
+        Click an image to read more.
+      </h1>
       <InstagramPageTemplate gallery={post.frontmatter.gallery} />
     </Layout>
   );
@@ -43,7 +52,7 @@ export const InstagramPageQuery = graphql`
               }
             }
           }
-          altText
+          title
           linkUrl
         }
       }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -75,7 +75,7 @@ collections:
                 [
                   { label: Link URL, name: linkUrl, widget: string },
                   { label: Image, name: image, widget: image },
-                  { label: Alt Text, name: altText, widget: string },
+                  { label: Title, name: title, widget: string },
                 ],
             }
       - file: 'src/pages/products/index.md'


### PR DESCRIPTION
Add margin to `blogCta` bottom,
Reverse order of Instagram posts on Instagram page,
Add heading to Instagram page for added clarity,
Make Instagram page grid 2-up until tablet where it becomes 3-up
